### PR TITLE
Added --check-status flag for http

### DIFF
--- a/lib/cli/HttpCli.js
+++ b/lib/cli/HttpCli.js
@@ -84,22 +84,24 @@ class HttpCli {
   /**
    * @method
    * @private
-   * 
+   *
    * @description wrap standard options for all http methods
    */
   _stdOptionWrapper(command) {
-    command.option('-H, --header <header>', 'Add additional Headers to the request')
-           .option('-P, --print <print>', 'Specify what components to print to user. Value should '+
-                    'be any combination of hbHB where: H=request headers, B=request body,'+
-                    'h=response headers and b=response body');
+    command
+    .option('-H, --header <header>', 'Add additional Headers to the request')
+    .option('--check-status','Return exit code for unsucessful calls')
+    .option('-P, --print <print>', 'Specify what components to print to user. Value should '+
+            'be any combination of hbHB where: H=request headers, B=request body,'+
+            'h=response headers and b=response body');
   }
 
   /**
    * @method
    * @private
    * @description parse given HTTP headers from command line and set to HTTP options
-   * 
-   * @param {Object} options HTTP request options 
+   *
+   * @param {Object} options HTTP request options
    * @param {Object} args command line options
    */
   _appendHeaders(options, args) {
@@ -115,8 +117,8 @@ class HttpCli {
    * @method
    * @private
    * @description parse given HTTP header from command line and set to HTTP options
-   * 
-   * @param {Object} options HTTP request options 
+   *
+   * @param {Object} options HTTP request options
    * @param {String} header HTTP header
    */
   _appendHeader(options, header) {
@@ -131,7 +133,7 @@ class HttpCli {
   /**
    * @method
    * @private
-   * 
+   *
    * @description parse the print arguments
    * @param {Object} args command line options
    */
@@ -157,13 +159,13 @@ class HttpCli {
   /**
    * @method
    * @private
-   * 
-   * @description print results of HTTP method
-   * 
+   *
+   * @description print results of HTTP method. Sets the exitCode of the call
+   *
    * @param {Object} args command args
    * @param {Object} response HTTP response object
    */
-  _display(args, response) {
+  _display_and_exitcode(args, response) {
     let print = this._parseDisplayOptions(args);
     let request = response.request;
 
@@ -188,12 +190,19 @@ class HttpCli {
       Logger.log(response.body);
       Logger.log();
     }
+
+    if (args.options['check-status']) {
+      if (!api.isSuccess(response)) {
+        process.exitCode= Math.floor(response.statusCode/100);
+      }
+    }
+
   }
 
   /**
    * @method
    * @private
-   * 
+   *
    * @description print HTTP headers to stdout
    * @param {Object} headers key/value pair hash
    */
@@ -207,9 +216,9 @@ class HttpCli {
   /**
    * @method
    * @private
-   * 
+   *
    * @description parse/handle the data-binary and data-string options for post/put cmds
-   * 
+   *
    * @param {Object} args command args
    * @param {Object} options HTTP request options
    * @returns {Boolean} was valid file or contents passed
@@ -248,9 +257,9 @@ class HttpCli {
   /**
    * @method
    * @private
-   * 
+   *
    * @description initialize the HTTP request options object for given path and headers
-   * 
+   *
    * @param {Object} args Command line arguments
    * @returns {Object} HTTP request options
    */
@@ -271,21 +280,21 @@ class HttpCli {
   /**
    * @method get
    * @description Handle 'http get' command
-   * 
-   * @param {Object} args Command line arguments 
+   *
+   * @param {Object} args Command line arguments
    */
   async get(args) {
     let options = this._initOptions(args);
     let {response, body} = await api.get(options);
-    this._display(args, response);
+    this._display_and_exitcode(args, response);
     return {response, options};
   }
 
   /**
    * @method post
    * @description Handle 'http post' command
-   * 
-   * @param {Object} args Command line arguments 
+   *
+   * @param {Object} args Command line arguments
    */
   async post(args) {
     let options = this._initOptions(args);
@@ -294,15 +303,15 @@ class HttpCli {
     if( !success ) return;
 
     let {response, body} = await api.post(options);
-    this._display(args, response);
+    this._display_and_exitcode(args, response);
     return {response, options};
   }
 
   /**
    * @method put
    * @description Handle 'http put' command
-   * 
-   * @param {Object} args Command line arguments 
+   *
+   * @param {Object} args Command line arguments
    */
   async put(args) {
     let options = this._initOptions(args);
@@ -311,15 +320,15 @@ class HttpCli {
     if( !success ) return;
 
     let {response, body} = await api.put(options);
-    this._display(args, response);
+    this._display_and_exitcode(args, response);
     return {response, options};
   }
 
   /**
    * @method patch
    * @description Handle 'http patch' command
-   * 
-   * @param {Object} args Command line arguments 
+   *
+   * @param {Object} args Command line arguments
    */
   async patch(args) {
     let options = this._initOptions(args);
@@ -329,43 +338,43 @@ class HttpCli {
     if( !success ) return;
 
     let {response, body} = await api.patch(options);
-    this._display(args, response);
+    this._display_and_exitcode(args, response);
     return {response, options};
   }
 
   /**
    * @method delete
    * @description Handle 'http delete' command
-   * 
-   * @param {Object} args Command line arguments 
+   *
+   * @param {Object} args Command line arguments
    */
   async delete(args) {
     let options = this._initOptions(args);
 
     let {response, body} = await api.delete(options);
-    this._display(args, response);
+    this._display_and_exitcode(args, response);
     return {response, options};
   }
 
   /**
    * @method head
    * @description Handle 'http head' command
-   * 
-   * @param {Object} args Command line arguments 
+   *
+   * @param {Object} args Command line arguments
    */
   async head(args) {
     let options = this._initOptions(args);
 
     let {response, body} = await api.head(options);
-    this._display(args, response);
+    this._display_and_exitcode(args, response);
     return {response, options};
   }
 
   /**
    * @method move
    * @description Handle 'http move' command
-   * 
-   * @param {Object} args Command line arguments 
+   *
+   * @param {Object} args Command line arguments
    */
   async move(args) {
     let options = this._initOptions(args);
@@ -373,17 +382,17 @@ class HttpCli {
     if( args.destination ) {
       options.destination = pathutils.makeAbsoluteFcPath(args.destination);
     }
-  
+
     let {response, body} = await api.move(options);
-    this._display(args, response);
+    this._display_and_exitcode(args, response);
     return {response, options};
   }
 
   /**
    * @method copy
    * @description Handle 'http copy' command
-   * 
-   * @param {Object} args Command line arguments 
+   *
+   * @param {Object} args Command line arguments
    */
   async copy(args) {
     let options = this._initOptions(args);
@@ -391,9 +400,9 @@ class HttpCli {
     if( args.destination ) {
       options.destination = pathutils.makeAbsoluteFcPath(args.destination);
     }
-  
+
     let {response, body} = await api.copy(options);
-    this._display(args, response);
+    this._display_and_exitcode(args, response);
     return {response, options};
   }
 


### PR DESCRIPTION
Allow for `fin http` commands to use `--check-status` flag.  With this set, process.exitCode is set to floor(http.status/100).

This allows testing like: 
```bash
fin  http get --check-status /does/not/exist
if [[ $? != 0 ]]; then echo 'Nope!'; fi
```bash
